### PR TITLE
fix: resolve FastAPI route ordering issue for node-templates endpoint

### DIFF
--- a/apps/backend/workflow_engine/scripts/check_node_templates.py
+++ b/apps/backend/workflow_engine/scripts/check_node_templates.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+Script to check and populate node_templates in the database
+"""
+import os
+import sys
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from sqlalchemy import create_engine, text
+from workflow_engine.core.config import get_settings
+
+def check_node_templates():
+    """Check if node_templates table has data"""
+    settings = get_settings()
+    engine = create_engine(settings.DATABASE_URL)
+    
+    with engine.connect() as conn:
+        # Check count
+        result = conn.execute(text("SELECT COUNT(*) FROM node_templates"))
+        count = result.scalar()
+        print(f"Current node_templates count: {count}")
+        
+        if count == 0:
+            print("No node templates found. The database needs to be seeded.")
+            print("\nTo fix this, run:")
+            print("psql $DATABASE_URL < database/seed_data.sql")
+        else:
+            # Show some examples
+            result = conn.execute(text("SELECT template_id, name, node_type, node_subtype FROM node_templates LIMIT 5"))
+            print("\nExample templates:")
+            for row in result:
+                print(f"  - {row.template_id}: {row.name} ({row.node_type}.{row.node_subtype})")
+
+if __name__ == "__main__":
+    check_node_templates()

--- a/apps/backend/workflow_engine/scripts/init_node_templates.py
+++ b/apps/backend/workflow_engine/scripts/init_node_templates.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Initialize node_templates in the database if empty.
+This script should be run on startup in production.
+"""
+import os
+import sys
+import logging
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from sqlalchemy import create_engine, text
+from workflow_engine.core.config import get_settings
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def init_node_templates():
+    """Initialize node_templates table with seed data if empty"""
+    settings = get_settings()
+    engine = create_engine(settings.DATABASE_URL)
+    
+    try:
+        with engine.connect() as conn:
+            # Check if node_templates is empty
+            result = conn.execute(text("SELECT COUNT(*) FROM node_templates"))
+            count = result.scalar()
+            
+            if count == 0:
+                logger.info("Node templates table is empty, initializing with seed data...")
+                
+                # Read and execute seed data
+                seed_file = Path(__file__).parent.parent / "database" / "seed_data.sql"
+                if seed_file.exists():
+                    with open(seed_file, 'r') as f:
+                        seed_sql = f.read()
+                    
+                    # Execute the seed data
+                    conn.execute(text(seed_sql))
+                    conn.commit()
+                    
+                    # Verify
+                    result = conn.execute(text("SELECT COUNT(*) FROM node_templates"))
+                    new_count = result.scalar()
+                    logger.info(f"Successfully initialized {new_count} node templates")
+                else:
+                    logger.error(f"Seed data file not found: {seed_file}")
+            else:
+                logger.info(f"Node templates already initialized with {count} templates")
+                
+    except Exception as e:
+        logger.error(f"Error initializing node templates: {e}")
+        raise
+
+if __name__ == "__main__":
+    init_node_templates()

--- a/apps/backend/workflow_engine/workflow_engine/api/v1/workflows.py
+++ b/apps/backend/workflow_engine/workflow_engine/api/v1/workflows.py
@@ -45,6 +45,24 @@ async def create_workflow(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get("/workflows/node-templates", response_model=List[NodeTemplate])
+async def list_node_templates(
+    category: Optional[str] = None,
+    include_system: bool = True,
+    service: WorkflowService = Depends(get_workflow_service),
+):
+    """
+    List all available node templates, with optional filters.
+    """
+    try:
+        templates = service.list_all_node_templates(
+            category_filter=category, include_system_templates=include_system
+        )
+        return templates
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.get("/workflows/{workflow_id}", response_model=GetWorkflowResponse)
 async def get_workflow(
     workflow_id: str, user_id: str, service: WorkflowService = Depends(get_workflow_service)
@@ -108,23 +126,5 @@ async def list_workflows(
             total_count=total_count,
             has_more=(offset + len(workflows)) < total_count,
         )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-@router.get("/workflows/node-templates", response_model=List[NodeTemplate])
-async def list_node_templates(
-    category: Optional[str] = None,
-    include_system: bool = True,
-    service: WorkflowService = Depends(get_workflow_service),
-):
-    """
-    List all available node templates, with optional filters.
-    """
-    try:
-        templates = service.list_all_node_templates(
-            category_filter=category, include_system_templates=include_system
-        )
-        return templates
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
- Move /workflows/node-templates route before /workflows/{workflow_id} to prevent path parameter matching
- Revert unnecessary parameter name changes in API Gateway client
- The issue was caused by FastAPI matching 'node-templates' as a workflow_id in the dynamic route